### PR TITLE
Add support for image_tag options

### DIFF
--- a/lib/filepicker/rails/view_helpers.rb
+++ b/lib/filepicker/rails/view_helpers.rb
@@ -21,6 +21,7 @@ module Filepicker
         button_tag(text, options)
       end
 
+      # Allows options to be passed to filepicker_image_url and then falls back to normal Rails options for image_tag
 
       def filepicker_image_tag(url, options={})
         image_tag(filepicker_image_url(url, options), options)


### PR DESCRIPTION
Add support for image_tag options.

Before you couldn't pass any Rails helper tag options like :class, :id, etc...
