### PR TITLE
Allow input field class to be specified

### DIFF
--- a/lib/filepicker/rails/form_builder.rb
+++ b/lib/filepicker/rails/form_builder.rb
@@ -23,7 +23,9 @@ module Filepicker
 
           'data-fp-drag-class' => options[:drag_class],
 
-          'onchange' => options[:onchange]
+          'onchange' => options[:onchange],
+          
+          'class' => options[:class]
         }
 
         type = options[:dragdrop] ? 'filepicker-dragdrop' : 'filepicker'


### PR DESCRIPTION
By specifying a :class attribute for filepicker_field, the field can be targeted by jQuery when multiple filepicker fields for the same model exist on the same page.
