### PR TITLE
README has incorrect example for filepicker_image_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ of an iframe on the page.
 
 ### Displaying an image:
 
-    <%= filepicker_image_tag @user.filepicker_url, w: 160, h: 160, fit: 'clip' %>
+    <%= filepicker_image_tag @user.filepicker_url, width: 160, height: 160, fit: 'clip' %>
 
 See [the filepicker.io documentation](https://developers.filepicker.io/docs/web/#fpurl-images) for the full options list.
 


### PR DESCRIPTION
The existing README shows 'w' and 'h' for width and height on the image tag, but actually the code uses 'width' and 'height'.  This pull request has an updated README with the correct tag.
