### PR TITLE
use w instead of width and h instead of h per filepicker.io documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ of an iframe on the page.
 
 ### Displaying an image:
 
-    <%= filepicker_image_tag @user.filepicker_url, width: 160, height: 160, fit: 'clip' %>
+    <%= filepicker_image_tag @user.filepicker_url, w: 160, h: 160, fit: 'clip' %>
 
 See [the filepicker.io documentation](https://developers.filepicker.io/docs/web/#fpurl-images) for the full options list.
 

--- a/lib/filepicker/rails/view_helpers.rb
+++ b/lib/filepicker/rails/view_helpers.rb
@@ -27,9 +27,9 @@ module Filepicker
         image_tag(filepicker_image_url(url, options), options)
       end
 
-      # width - Resize the image to this width.
+      # w - Resize the image to this width.
       #
-      # height - Resize the image to this height.
+      # h - Resize the image to this height.
       #
       # fit - Specifies how to resize the image. Possible values are:
       #       clip: Resizes the image to fit within the specified parameters without
@@ -66,7 +66,7 @@ module Filepicker
       #                 and horizontal with a comma. The default behavior
       #                 is bottom,right
       def filepicker_image_url(url, options = {})
-        query_params = options.slice(:width, :height, :fit, :align, :crop, :format, :quality, :watermark, :watersize, :waterposition).to_query
+        query_params = options.slice(:w, :h, :fit, :align, :crop, :format, :quality, :watermark, :watersize, :waterposition).to_query
         [url, "/convert?", query_params].join
       end
 


### PR DESCRIPTION
In the helper method it was appending width and height as the query parameters, the documentation requires it to be w and h per filepickers api.
