### PR TITLE
View helper method to use in form_tag

### DIFF
--- a/lib/filepicker/rails/view_helpers.rb
+++ b/lib/filepicker/rails/view_helpers.rb
@@ -84,8 +84,8 @@ module Filepicker
           'data-fp-option-services' => Array(options[:services]).join(","),
           'data-fp-drag-text' => options.fetch(:drag_text, "Or drop files here"),
           'data-fp-drag-class' => options[:drag_class],
-          'data-fp-signature' => options[:signature]
-          'data-fp-policy' => options[:policy]
+          'data-fp-signature' => options[:signature],
+          'data-fp-policy' => options[:policy],
           'onchange' => options[:onchange]
         }
 


### PR DESCRIPTION
When we have a form_for this gem works fine with form_builder.
There was no support for form_tag situation. I added a helper method for that.
