### PR TITLE
filepicker_image_tag with width and height not rendering correctly

### DIFF
--- a/lib/filepicker/rails/view_helpers.rb
+++ b/lib/filepicker/rails/view_helpers.rb
@@ -23,8 +23,8 @@ module Filepicker
 
       # Allows options to be passed to filepicker_image_url and then falls back to normal Rails options for image_tag
       # If specifying html width, height, pass it down to filepicker for optimization
-      def filepicker_image_tag(url, options={})
-        image_tag(filepicker_image_url(url, options))
+      def filepicker_image_tag(url, image_options={}, image_tag_options={})
+        image_tag(filepicker_image_url(url, image_options), image_tag_options)
       end
 
       # w - Resize the image to this width.


### PR DESCRIPTION
Using the `filepicker_image_tag` with a determined width and height, renders the html like so

![Screen Shot 2013-04-23 at 6 43 11 PM](https://f.cloud.github.com/assets/469507/417594/9dda8c8c-ac6f-11e2-9ed0-7f9925dbd338.png)

Making the image squared in every case.

I removed the options from the image_tag to solve this
