### PR TITLE
Fix Rails 4 attribute name and model

### DIFF
--- a/lib/filepicker/rails/form_builder.rb
+++ b/lib/filepicker/rails/form_builder.rb
@@ -12,7 +12,7 @@ module Filepicker
         input_options['type'] = type
 
         if ::Rails.version.to_i >= 4
-          ActionView::Helpers::Tags::TextField.new(@object_name, method, @template).tag('input', input_options)
+          ActionView::Helpers::Tags::TextField.new(@object_name, method, @template, objectify_options(input_options)).render
         else
           ActionView::Helpers::InstanceTag.new(@object_name, method, @template).to_input_field_tag(type, input_options)
         end


### PR DESCRIPTION
On Rails 4 the generated form fields have an incorrect name attribute (particularly with nested models) and don't include the existing value from the model.  This small patch fixes both issues.
