### PR TITLE
Fix broken specs

### DIFF
--- a/app/helpers/filepicker_rails/form_helper.rb
+++ b/app/helpers/filepicker_rails/form_helper.rb
@@ -7,6 +7,7 @@ module FilepickerRails
       input_options = retrive_legacy_filepicker_options(options)
       input_options['data-fp-apikey'] ||= ::Rails.application.config.filepicker_rails.api_key
       input_options.merge!(secure_filepicker) unless input_options['data-fp-policy'].present?
+      input_options['type'] = type
 
       if ::Rails.version.to_i >= 4
         tag = ActionView::Helpers::Tags::TextField.new(@object_name, method, @template, objectify_options(input_options))


### PR DESCRIPTION
Some merge after the rails engine, accidently anyone removed the following line on form_helper.rb:

``` ruby
input_options['type'] = type
```

without this the input is generated with `type="text"` over `type="filepicker"`, as the [documentation suggest](https://developers.inkfilepicker.com/docs/web/#widgets) without the correct type the JS not work correctly.

I fixed this. I suggest only accept pull request with specs from now on. I I`ll make a PR to add travis, this way we know we have a broken spec directly on github =)
