### PR TITLE
Add CDN configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ Set your API Key in config/application.rb:
 config.filepicker_rails.api_key = "Your filepicker.io API Key"
 ```
 
+Set your CDN Path in config/production.rb ([CDN usage](https://developers.inkfilepicker.com/docs/cdn/)):
+
+```ruby
+config.filepicker_rails.cdn_host = "Your CDN host name"
+```
+
 ## Usage
+
 ### First create a migration to add the field that will hold your filepicker.io URL
+
 Run the Rails migration generator from the command line:
 
     $ rails g migration AddNameOfAttrForFilepickerUrlToUser
@@ -54,7 +62,6 @@ class AddNameOfAttrForFilepickerUrlToUser < ActiveRecord::Migration
 end
 ```
 
-
 ### Adding an upload field to your form:
 
 ```erb
@@ -67,6 +74,7 @@ end
   <%= f.submit %>
 <% end %>
 ```
+
 Full options list:
 
 * button_text - The text of the upload button.
@@ -115,7 +123,6 @@ Example fpfiles object:
 ```
 
 See [the filepicker.io documentation](https://developers.filepicker.io/docs/web/#fpurl-images) for the full options list.
-
 
 ### Allowing the user to download a file (or upload it to any of the supported services)
 

--- a/app/helpers/filepicker_rails/application_helper.rb
+++ b/app/helpers/filepicker_rails/application_helper.rb
@@ -70,6 +70,12 @@ module FilepickerRails
     #                 is bottom,right
     def filepicker_image_url(url, options = {})
       query_params = options.slice(:w, :h, :fit, :align, :cache, :crop, :format, :quality, :watermark, :watersize, :waterposition).to_query
+
+      if ::Rails.application.config.filepicker_rails.cdn_host
+        uri = URI.parse(url)
+        url.gsub!("#{uri.scheme}://#{uri.host}", ::Rails.application.config.filepicker_rails.cdn_host)
+      end
+
       [url, "/convert?", query_params].join
     end
   end

--- a/lib/filepicker_rails/configuration.rb
+++ b/lib/filepicker_rails/configuration.rb
@@ -1,13 +1,10 @@
 module FilepickerRails
   class Configuration
-    attr_writer :api_key, :secret_key, :default_expiry
+    attr_writer :api_key, :default_expiry
+    attr_accessor :secret_key, :cdn_host
 
     def api_key
       @api_key or raise "Set config.filepicker_rails.api_key"
-    end
-
-    def secret_key
-      @secret_key
     end
 
     def default_expiry

--- a/spec/helpers/aplication_helper_spec.rb
+++ b/spec/helpers/aplication_helper_spec.rb
@@ -141,5 +141,14 @@ describe FilepickerRails::ApplicationHelper do
         expect(filepicker_image_url("foo", waterposition: 'top')).to eq('foo/convert?waterposition=top')
       end
     end
+
+    context "with cdn host" do
+
+      it "have url with cdn host" do
+        ::Rails.application.config.filepicker_rails.stub(cdn_host: "//cdn.example.com")
+
+        expect(filepicker_image_url("https://www.filepicker.io/foo")).to eq("//cdn.example.com/foo/convert?")
+      end
+    end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -60,5 +60,17 @@ describe FilepickerRails::Configuration do
       expect(configuration.default_expiry).to eq(600)
     end
   end
+
+  describe "#cdn_host" do
+
+    it "have defined value" do
+      configuration.cdn_host = "https://cdn.example.com"
+      expect(configuration.cdn_host).to eq("https://cdn.example.com")
+    end
+
+    it "have a default value" do
+      expect(configuration.cdn_host).to eq(nil)
+    end
+  end
 end
 


### PR DESCRIPTION
Let me know how you guys feel about this. When using `filepicker_image_url` it will substitute the `www.filepicker.io` url with a configured CDN host.
- Update README
- Add regex replacement of filepicker.io URL with CDN URL
