### PR TITLE
Change when Filepicker Application helper is loaded

### DIFF
--- a/lib/filepicker_rails/engine.rb
+++ b/lib/filepicker_rails/engine.rb
@@ -8,8 +8,8 @@ module FilepickerRails
     end
 
     initializer 'filepicker_rails.action_controller' do |app|
-      ActiveSupport.on_load(:action_controller) do
-        helper FilepickerRails::ApplicationHelper
+      ActiveSupport.on_load(:action_view) do
+        include FilepickerRails::ApplicationHelper
       end
     end
   end


### PR DESCRIPTION
- helpers like filepicker_js_include_tag aren't available unless they are included when ActionView is loaded.
