### PR TITLE
Add note to require filepicker-rails in config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Add the filepicker.io javascript library to your layout:
 <%= filepicker_js_include_tag %>
 ```
 
+Require filepicker-rails in config/application.rb:
+
+```ruby
+require "filepicker-rails"
+```
+
 Set your API Key in config/application.rb:
 
 ```ruby


### PR DESCRIPTION
I called the filepicker_js_include_tag helper like I've done on v.0.1 projects, but I received an error stating that it was not defined. I had to include filepicker in my application.rb for it to show.
