### PR TITLE
Add filepicker_image_url to work with policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1 (Unreleased)
+
+### features
+
+- filepicker_image_tag now works with policies
+
 ## 1.1.0 (March 30, 2014)
 
 ### features

--- a/app/helpers/filepicker_rails/application_helper.rb
+++ b/app/helpers/filepicker_rails/application_helper.rb
@@ -73,18 +73,73 @@ module FilepickerRails
     #                 and horizontal with a comma. The default behavior
     #                 is bottom,right
     def filepicker_image_url(url, options = {})
-      query_params = options.slice(:w, :h, :fit, :align, :rotate, :cache, :crop, :format, :quality, :watermark, :watersize, :waterposition).to_query
+      FilepickerImageUrl.new(url, options).execute
+    end
 
-      if ::Rails.application.config.filepicker_rails.cdn_host
-        uri = URI.parse(url)
-        url.gsub!("#{uri.scheme}://#{uri.host}", ::Rails.application.config.filepicker_rails.cdn_host)
+    class FilepickerImageUrl
+
+      VALID_OPTIONS = [:w, :h, :fit, :align, :rotate, :cache, :crop, :format,
+                       :quality, :watermark, :watersize, :waterposition]
+
+      def initialize(url, options = {})
+        @url, @options = url, options
+        remove_invalid_options
+        apply_cdn_to_url
+        apply_policy
       end
 
-      if query_params.blank?
-        [url, query_params]
-      else
-        [url, "/convert?", query_params]
-      end.join
+      def execute
+        query_params = options.to_query
+        if has_convert_options?
+          [url, '/convert?', query_params]
+        elsif has_policy?
+          [url,'?', query_params]
+        else
+          [url, query_params]
+        end.join
+      end
+
+      private
+
+        attr_reader :url, :options
+
+        def remove_invalid_options
+          options.delete_if{ |o| !VALID_OPTIONS.include?(o) }
+        end
+
+        def cdn_host
+          ::Rails.application.config.filepicker_rails.cdn_host
+        end
+
+        def has_policy?
+          policy_config.any?
+        end
+
+        def has_convert_options?
+          options.keys.any?{ |k| VALID_OPTIONS.include?(k) }
+        end
+
+        def apply_cdn_to_url
+          if cdn_host
+            uri = URI.parse(url)
+            url.gsub!("#{uri.scheme}://#{uri.host}", cdn_host)
+          end
+        end
+
+        def apply_policy
+          options.merge!(policy_config)
+        end
+
+        def policy_config
+          return {} unless ::Rails.application.config.filepicker_rails.secret_key.present?
+          grant = Policy.new
+          grant.call = [:pick, :store]
+
+          {
+            'policy' => grant.policy,
+            'signature' => grant.signature
+          }
+        end
     end
   end
 end

--- a/spec/helpers/aplication_helper_spec.rb
+++ b/spec/helpers/aplication_helper_spec.rb
@@ -159,5 +159,32 @@ describe FilepickerRails::ApplicationHelper do
         expect(filepicker_image_url("https://www.filepicker.io/foo")).to eq("//cdn.example.com/foo")
       end
     end
+
+    context 'with policy' do
+
+      before do
+        Timecop.freeze(Time.zone.parse("2012-09-19 12:59:27"))
+        Rails.application.config.filepicker_rails.secret_key = 'filepicker123secretkey'
+      end
+
+      after do
+        Rails.application.config.filepicker_rails.secret_key = nil
+        Timecop.return
+      end
+
+      it 'have policy and signature' do
+        url = 'foo?policy=eyJleHBpcnkiOjEzNDgwNjAxNjcsImNhbGwiOlsicGljayIsInN0b3JlIl19' \
+              '&signature=7bbfb03a94967056d4c98140a3ce188ec7a5b575d2cd86fe5528d7fafb3387c3'
+        expect(filepicker_image_url('foo')).to eq(url)
+      end
+
+      it 'have policy and signature when have some convert option' do
+        url = 'foo/convert' \
+              '?policy=eyJleHBpcnkiOjEzNDgwNjAxNjcsImNhbGwiOlsicGljayIsInN0b3JlIl19' \
+              '&quality=80' \
+              '&signature=7bbfb03a94967056d4c98140a3ce188ec7a5b575d2cd86fe5528d7fafb3387c3'
+        expect(filepicker_image_url('foo', quality: 80)).to eq(url)
+      end
+    end
   end
 end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'timecop'
 
 describe FilepickerRails::FormHelper do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'capybara/rails'
 require 'capybara/rspec'
+require 'timecop'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Closes  #93 

@bcackerman do you can test the policies with this branch? As you [can see now it is appended the signature and policy to query](https://github.com/Ink/filepicker-rails/blob/13775bae12decb190eb706d75cca0a65413d3c8a/spec/helpers/aplication_helper_spec.rb#L175-L186) as documented [here](https://developers.inkfilepicker.com/docs/security/#usePolicy).

Please test this with a convertions and without a convertion.
