### PR TITLE
changing helper to fix issue with filepicker_save_link

### DIFF
--- a/app/helpers/filepicker_rails/application_helper.rb
+++ b/app/helpers/filepicker_rails/application_helper.rb
@@ -58,7 +58,7 @@ module FilepickerRails
     # - `:container` - Where to show the file picker dialog can be `modal`,
     # `window` or the id of an iframe on the page.
     # - `:services` - What services your users can upload to. Ex: `BOX, COMPUTER, FACEBOOK`.
-    # - `:save_as_name` - A recommended file name. The user can override this.
+    # - `:suggestedFilename` - A recommended file name. The user can override this.
     #
     # #### Examples
     #
@@ -81,7 +81,7 @@ module FilepickerRails
     # - `:container` - Where to show the file picker dialog can be `modal`,
     # `window` or the id of an iframe on the page.
     # - `:services` - What services your users can upload to. Ex: `BOX, COMPUTER, FACEBOOK`.
-    # - `:save_as_name` - A recommended file name. The user can override this.
+    # - `:suggestedFilename` - A recommended file name. The user can override this.
     #
     # #### Examples
     #

--- a/app/helpers/filepicker_rails/application_helper.rb
+++ b/app/helpers/filepicker_rails/application_helper.rb
@@ -258,9 +258,9 @@ module FilepickerRails
         options[:data]['fp-url'] = url
         options[:data]['fp-apikey'] = ::Rails.application.config.filepicker_rails.api_key
         options[:data]['fp-mimetype'] = mimetype
-        options[:data]['fp-option-container'] = container if container
-        options[:data]['fp-option-services'] = Array(services).join(",") if services
-        options[:data]['fp-option-defaultSaveasName'] = save_as if save_as
+        options[:data]['fp-container'] = container if container
+        options[:data]['fp-services'] = Array(services).join(",") if services
+        options[:data]['fp-suggestedFilename'] = save_as if save_as
         block.call
       end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -72,25 +72,25 @@ RSpec.describe FilepickerRails::ApplicationHelper do
 
       describe "container" do
 
-        it "have the data-fp-option-container attribute" do
-          attribute = %{data-fp-option-container="modal"}
+        it "have the data-fp-container attribute" do
+          attribute = %{data-fp-container="modal"}
           expect(filepicker_save_button('save', '/foo', 'image/jpg', container: 'modal')).to include(attribute)
         end
       end
 
       describe "services" do
 
-        it "have the data-fp-option-services attribute" do
-          attribute = %{data-fp-option-services="COMPUTER, FACEBOOK"}
+        it "have the data-fp-services attribute" do
+          attribute = %{data-fp-services="COMPUTER, FACEBOOK"}
           expect(filepicker_save_button('save', '/foo', 'image/jpg', services: 'COMPUTER, FACEBOOK')).to include(attribute)
         end
       end
 
-      describe "save_as_name" do
+      describe "suggestedFilename" do
 
-        it "have the data-fp-option-defaultSaveasName attribute" do
-          attribute = %{data-fp-option-defaultSaveasName="myfile"}
-          expect(filepicker_save_button('save', '/foo', 'image/jpg', save_as_name: 'myfile')).to include(attribute)
+        it "have the data-fp-suggestedFilename attribute" do
+          attribute = %{data-fp-suggestedFilename="myfile"}
+          expect(filepicker_save_button('save', '/foo', 'image/jpg', suggestedFilename: 'myfile')).to include(attribute)
         end
       end
     end
@@ -109,21 +109,21 @@ RSpec.describe FilepickerRails::ApplicationHelper do
       describe "container" do
 
         it "have the correct link" do
-          expect(filepicker_save_link('save', '/foo', 'image/jpg', container: 'modal')).to eq(build_link('fp-option-container' => 'modal'))
+          expect(filepicker_save_link('save', '/foo', 'image/jpg', container: 'modal')).to eq(build_link('fp-container' => 'modal'))
         end
       end
 
       describe "services" do
 
         it "have the correct link" do
-          expect(filepicker_save_link('save', '/foo', 'image/jpg', services: 'COMPUTER, FACEBOOK')).to eq(build_link('fp-option-services' => 'COMPUTER, FACEBOOK'))
+          expect(filepicker_save_link('save', '/foo', 'image/jpg', services: 'COMPUTER, FACEBOOK')).to eq(build_link('fp-services' => 'COMPUTER, FACEBOOK'))
         end
       end
 
-      describe "save_as_name" do
+      describe "suggestedFilename" do
 
         it "have the correct link" do
-          expect(filepicker_save_link('save', '/foo', 'image/jpg', save_as_name: 'myfile')).to eq(build_link('fp-option-defaultSaveasName' => 'myfile'))
+          expect(filepicker_save_link('save', '/foo', 'image/jpg', suggestedFilename: 'myfile')).to eq(build_link('fp-suggestedFilename' => 'myfile'))
         end
       end
     end


### PR DESCRIPTION
I was working with a customer who was having trouble getting filepicker_save_link to work.

The gem was rendering the export tag with the following fields:

data-fp-option-services="BOX" and data-fp-option-defaultsaveasname="exampleName"

These needed to be data-fp-services and data-fp-suggestedFilename.

I found that they appeared to be wrong in the export widget method of the helper, and suggested the customer change them. He updated the helper himself and that fixed his issue, so I am issuing a pull request to update the helper.
