### PR TITLE
Fix helper inclusion for Rails 5

### DIFF
--- a/lib/filepicker_rails/engine.rb
+++ b/lib/filepicker_rails/engine.rb
@@ -10,7 +10,7 @@ module FilepickerRails
 
     initializer 'filepicker_rails.action_controller' do |app|
       ActiveSupport.on_load(:action_controller) do
-        helper FilepickerRails::ApplicationHelper
+        ::ActionController::Base.helper(FilepickerRails::ApplicationHelper)
       end
     end
   end


### PR DESCRIPTION
Calling the `helper` method after upgrading to Rails 5 resulted in the
following error:

```
undefined method 'helper' for ActionController::API:Class
```

This commit follows the lead of the following commit on another project:
https://github.com/weppos/breadcrumbs_on_rails/commit/3a3ac0c0d42bb0535418942e9051d687661582e5
