### PR TITLE
Allow to customize input id

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Add the Filestack File Picker and initialization script to your layout:
 
 ```erb
 <%= filestack_js_include_tag %>
-<%= filestack_js_init_tag %> 
+<%= filestack_js_init_tag %>
 ```
 
-Please note: the scripts need to be added before your application's custom scripts, e.g. before any scripts in your assets folder, if you need access the Filestack client in your own Javascript. 
+Please note: the scripts need to be added before your application's custom scripts, e.g. before any scripts in your assets folder, if you need access the Filestack client in your own Javascript.
 
 Set your API key and client name in `config/application.rb`:
 
@@ -46,7 +46,7 @@ Set your API key and client name in `config/application.rb`:
 config.filestack_rails.api_key = "Your Filestack API Key"
 config.filestack_rails.client_name = "custom_client_name"
 ```
-The client name defaults to "filestack_client" and is injected into your client-side Javascript. This is because v3 of the File Picker lives in the Javascript of your web application. For more information, please see our [File Picker documenation](https://www.filestack.com/docs/javascript-api/pick-v3). 
+The client name defaults to "filestack_client" and is injected into your client-side Javascript. This is because v3 of the File Picker lives in the Javascript of your web application. For more information, please see our [File Picker documenation](https://www.filestack.com/docs/javascript-api/pick-v3).
 
 ### Security
 
@@ -68,19 +68,19 @@ You can access the generated policy and signature anytime by calling their attri
 puts config.filestack_rails.security.policy
 puts config.filestack_rails.security.signature
 ```
-You can also generate a new security object at any time, although this will only affect the filestack_image tag, and not the File Picker client. 
+You can also generate a new security object at any time, although this will only affect the filestack_image tag, and not the File Picker client.
 
 ## Usage
 
-Filestack::Rails provides three main functionalities: 
+Filestack::Rails provides three main functionalities:
 
 ### Filestack Upload Button
 This is a generic button that can be added anywhere in your application and opens an instance of the File Picker. Once a user has chosen a file(s) and submitted, a callback will be executed, passing in the results. You can also pass in any options for the File Picker using the pickerOptions symbol:
 
 ```erb
-<%= filestack_picker_element 'button test', 'callbackForButton', id: 'someuniequeid', pickerOptions: { 'fromSources' => 'facebook' } %>
+<%= filestack_picker_element 'button test', 'callbackForButton', id: 'someuniqueid', input_id: 'someuniqueinputid', pickerOptions: { 'fromSources' => 'facebook' } %>
 ```
-File Picker options are exactly the same as in the Javscript SDK and can be found in the aforementioned documentation. 
+File Picker options are exactly the same as in the Javscript SDK and can be found in the aforementioned documentation.
 
 The callback can be either the name of a function you've defined in your main Javascript or it can be any code that is immediately executable, e.g. "console.log" or "(function(data){console.log(data)})". The callback should take in a response array as its only argument, which has the following structure:
 
@@ -116,7 +116,7 @@ The form helper wraps the generic Pick element and adds the value of the returne
 ```erb
 <%= form_for @user do |f| %>
   <div>
-    <%= f.filestack_field :filepicker_url, 'Upload Your Avatar!',  pickerOptions: {'fromSources': 'facebook'}, id: 'unique-id' %> 
+    <%= f.filestack_field :filepicker_url, 'Upload Your Avatar!',  pickerOptions: {'fromSources': 'facebook'}, id: 'unique-id', input_id: 'unique-input-id' %>
   </div>
 
   <%= f.submit %>
@@ -129,16 +129,16 @@ Filestack::Rails now has access to the full list of image transforms through our
 <%= filestack_image @user.filepicker_url, transform: filestack_transform.resize(width:100, height:100).flip.enhance %>
 ```
 ## Migrating from 2.x to 3.x
-Filestack::Rails 3.x is a significant and breaking change. Users wishing to upgrade will need to change their current implementation in order to use the plugin correctly. 
+Filestack::Rails 3.x is a significant and breaking change. Users wishing to upgrade will need to change their current implementation in order to use the plugin correctly.
 ### Javascript-based File Picker
 The v3 File Picker is a Javascript application that lives on the client-side of your application. This means you have greater control and access to when it is called, access to the rest of the web SDK, as well as being able to pass callbacks executed once uploads have completed. You must keep in mind the File Picker client lives in global scope and adjust your namespaces accordingly, although you can also change the name of the client, as detailed in the above sections.
 ### Form Helper
-The form helper's call remains essentially the same, except that it now takes as its argument the value of the button element displayed on the page. 
+The form helper's call remains essentially the same, except that it now takes as its argument the value of the button element displayed on the page.
 ```erb
 <%= f.filestack_field :filestack_url, 'Pick Your Avatar' >
 ```
 ### Save Button
-As user saving/downloading is not currently supported in the v3 File Picker, that functionality has been removed from Filestack::Rails for the time being. 
+As user saving/downloading is not currently supported in the v3 File Picker, that functionality has been removed from Filestack::Rails for the time being.
 ### Transformations
 The filestack_image tag wraps the generic Rails image_tag and generates a new URL with use of the Ruby SDK. This provides the entire scope of the possible transformations through Filestack's transformation engine, minus those which do not return an image (like debug, av_convert, and so forth). Defining transformations is as simple as chaining them together using the filestack_transform method:
 ```erb
@@ -148,11 +148,11 @@ The filestack_image tag wraps the generic Rails image_tag and generates a new UR
 Filestack::Rails injects the Filestack Ruby SDK into your application for use anywhere. You can use it to access the rest of the Filestack API and find its documentation [here](https://github.com/filestack/filestack-ruby)
 ## Demo
 
-To see the Filestack::Rails plugin in action, clone this repository and run the demo app by following these instructions (will only work in Rails 5.x): 
+To see the Filestack::Rails plugin in action, clone this repository and run the demo app by following these instructions (will only work in Rails 5.x):
 
 ### Set API key
 
-Go to ```spec/dummy/config/application.rb``` and change the API key to your own. 
+Go to ```spec/dummy/config/application.rb``` and change the API key to your own.
 
 ### Install Dependencies
 

--- a/app/helpers/filestack_rails/form_helper.rb
+++ b/app/helpers/filestack_rails/form_helper.rb
@@ -10,7 +10,7 @@ module FilestackRails
 
     def get_filestack_field_button(method, content, options = {})
       input_options = {}
-      input_options[:id] = "#{@object.class.name.downcase}_#{method.downcase}"
+      input_options[:id] = filestack_input_field_id(method, options[:input_id])
       input_options[:style] = 'display:none'
       user_callback = options[:callback] || nil
       options.delete(:callback)
@@ -22,11 +22,15 @@ module FilestackRails
       unless user_callback.nil?
         form_field_callback_guts = "#{form_field_callback_guts}#{user_callback}(data)"
       end
-      
+
       form_field_callback = "(function(data){#{form_field_callback_guts}})"
 
       html_string = "#{filestack_picker_element(content, form_field_callback, options)}#{text_field(method, input_options)}"
       raw html_string.html_safe
+    end
+
+    def filestack_input_field_id(method, input_id)
+      input_id.presence || "#{@object.class.name.downcase}_#{method.downcase}"
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FilestackRails::ApplicationHelper do
     end
   end
 
-  describe "#filestack_picker_element" do 
+  describe "#filestack_picker_element" do
     it "has the right picker element" do
       html_string = filestack_picker_element "hello!", "console.log('hello!')"
       correct_string = '<button name="button" type="button" onclick="(function(){
@@ -38,7 +38,7 @@ RSpec.describe FilestackRails::ApplicationHelper do
   end
 
   describe "#filestack_image" do
-    it "returns the correct tag" do 
+    it "returns the correct tag" do
       image = filestack_image 'www.example.com', transform: filestack_transform.resize(width: 100, height: 100)
       correct = '<img src="https://cdn.filestackcontent.com/API_KEY/resize=width:100,height:100/www.example.com" alt="Www.example" />'
       expect(image).to eq(correct)

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -5,10 +5,26 @@ RSpec.describe FilestackRails::ApplicationHelper do
   include FilestackRails::FormHelper
   include ActionView::Helpers
   describe '#filestack_field' do
+
     it "provides the correct form_tag" do
       output = filestack_field :picture, "some content"
       expect(output).to include("<button")
-      expect(output).to include("</button>")     
+      expect(output).to include("</button>")
+    end
+
+    it 'provides the default input id' do
+      @object = Object.new
+      output = filestack_field :picture, 'some content'
+      expect(output).to include('object_picture')
+    end
+
+    context 'when options input_id is set' do
+      let(:options) { {input_id: 'my_custom_id'} }
+
+      it 'provides the correct input_id' do
+        output = filestack_field :picture, 'some content', options
+        expect(output).to include('my_custom_id')
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

Sorry for the disturb of the last pull request #177.

I remind you what the problem:
>We have multiple filestack_field in the same page with the same input-id.
>get_filestack_field_button returns always the same id for the input, and this is a problem.
>Here we can customize every id of your input.

Regards