### PR TITLE
Update filestack dependency

### DIFF
--- a/filestack-rails.gemspec
+++ b/filestack-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency 'rails', '>= 4.0'
-  s.add_dependency "filestack", "~> 2.1.0"
+  s.add_dependency "filestack", "~> 2.2.1"
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Hi
Could you please release a new version that allows the latest `filestack` gem (2.2.1)?
There is a  postgres conflict with v2.1.0: https://github.com/filestack/filestack-ruby/issues/13