### PR TITLE
Bump filestack-ruby to latest release

### DIFF
--- a/filestack-rails.gemspec
+++ b/filestack-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency 'rails', '>= 4.0'
-  s.add_dependency "filestack", "~> 2.2.1"
+  s.add_dependency "filestack", "~> 2.4.0"
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
I'd love to get the latest improvements of the filestack-ruby lib into this one. Especially since this solves #172 

The tests seem to be passing, but let me know if there is anything to be aware of.