### PR TITLE
Fix missing api_key message

### DIFF
--- a/lib/filestack_rails/configuration.rb
+++ b/lib/filestack_rails/configuration.rb
@@ -3,7 +3,7 @@ module FilestackRails
     attr_accessor :api_key, :client_name, :secret_key, :security, :expiry, :app_secret, :cname
 
     def api_key
-      @api_key or raise "Set config.filepicker_rails.api_key"
+      @api_key or raise "Set config.filestack_rails.api_key"
     end
 
     def client_name


### PR DESCRIPTION
If `filestack_rails.api_key` is missing from the configuration, the error message says:

`Set config.filepicker_rails.api_key`

It should say:

`Set config.filestack_rails.api_key`

