### PR TITLE
Fix helper without options renders faulty JS

### DIFF
--- a/app/helpers/filestack_rails/application_helper.rb
+++ b/app/helpers/filestack_rails/application_helper.rb
@@ -48,20 +48,31 @@ module FilestackRails
     end
 
     def create_javascript_for_picker(callback, options)
-      client_name, = get_client_and_api_key
+      client_name, _api_key = get_client_and_api_key
       json_string = if options.nil?
                       ''
                     else
                       options.to_json
                     end
-      v2 = -> { "(function(){
-        #{client_name}.pick(#{json_string}).then(function(data){#{callback}(data)})
-      })()" }
 
-      v3 = -> { json_string = "#{json_string}".slice!(1, json_string.length-2) # removed curly brackets help to generate pickerOptions in js
-                "(function(){
-                  #{client_name}.picker({#{json_string}, onUploadDone: data => #{callback}(data)}).open()
-                })()" }
+      v2 = -> do
+        <<~HTML
+          (function(){
+            #{client_name}.pick(#{json_string}).then(function(data){#{callback}(data)})
+          })()
+        HTML
+      end
+
+      v3 = -> do
+        json_string = json_string[1..-2] # removed curly brackets help to generate pickerOptions in js
+
+        <<~HTML
+          (function(){
+            #{client_name}.picker({ onUploadDone: data => #{callback}(data), #{json_string} }).open()
+          })()
+        HTML
+      end
+
       get_filestack_js_result(v2: v2, v3: v3)
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -29,10 +29,12 @@ RSpec.describe FilestackRails::ApplicationHelper do
 
   describe "#filestack_picker_element" do
     it "has the right picker element" do
-      html_string = filestack_picker_element "hello!", "console.log('hello!')"
+      html_string = filestack_picker_element("hello!", "console.log('hello!')").gsub(/\s+/, ' ')
+
       correct_string = '<button name="button" type="button" onclick="(function(){
-                  rich_client.picker({, onUploadDone: data =&gt; console.log(&#39;hello!&#39;)(data)}).open()
-                })()">hello!</button>'
+                          rich_client.picker({ onUploadDone: data =&gt; console.log(&#39;hello!&#39;)(data), }).open()
+                        })() ">hello!</button>'.gsub(/\s+/, ' ')
+
       expect(html_string).to eq(correct_string)
     end
   end


### PR DESCRIPTION
#200 Filestack Form Helper with no options renders javascript syntax error

Simply moving `#{json_string}` (line 71) to the end of the object fixes this, but I had a hard time reading this code so I took the liberty of refactoring a little bit